### PR TITLE
FIX: Flood protection

### DIFF
--- a/src/bot/broker/broker.hpp
+++ b/src/bot/broker/broker.hpp
@@ -85,11 +85,14 @@ namespace kbot
   : m_on_ipc_fail(_cb)
   {
     kiq::log::klogger::init("botbroker", "trace");
+
     const auto execpath = get_executable_cwd();
-    klogger::instance().d("Exec path is {}", execpath);
-    const auto config        = INIReader{execpath + "../config.ini"};
+    const auto config   = INIReader{execpath + "../config/config.ini"};
+
+    klog().d("Exec path is {}", execpath);
+
     if (config.ParseError() < 0)
-      klogger::instance().i("Failed to load config");
+      klog().i("Failed to load config");
     else
       m_flood_protect = config.GetBoolean("broker", "flood_protect", false);
 
@@ -99,7 +102,7 @@ namespace kbot
     m_pool.push_back(&m_bg_bot);
     m_pool.push_back(&m_tg_bot);
     m_pool.push_back(&m_mx_bot);
-    // m_pool.push_back(&m_gt_bot);
+    m_pool.push_back(&m_gt_bot);
     m_pool.push_back(&m_ig_bot);
 
     for (auto&& bot : m_pool)

--- a/src/bot/instagram/instagram.hpp
+++ b/src/bot/instagram/instagram.hpp
@@ -66,7 +66,7 @@ InstagramBot& operator=(const InstagramBot& bot)
 virtual void Init(bool flood_protect) final
 {
   m_flood_protect = flood_protect;
-  klogger::instance().i("Setting flood protection to {}", flood_protect);
+  klog().i("Setting flood protection to {}", flood_protect);
   return;
 }
 //-------------------------------------------------------------
@@ -93,11 +93,13 @@ bool HandleEvent(const BotRequest& request)
   std::string err_msg;
   try
   {
-    if (m_flood_protect && post_requested(request.id))
-      klogger::instance().w("{} was already requested", request.id);
-    else
     if (event == "livestream active" || event == "platform:repost" || event == "instagram:messages")
     {
+      if (m_flood_protect && post_requested(request.id))
+      {
+        klogger::instance().w("{} was already requested", request.id);
+        return false;
+      }
 
       m_pending++;
       m_worker.send(BotRequestToIPC(Platform::instagram, request));

--- a/src/bot/matrix/matrix.hpp
+++ b/src/bot/matrix/matrix.hpp
@@ -155,9 +155,12 @@ MatrixBot& operator=(const MatrixBot& m)
       {
         m_pending++;
         BotRequest outbound = request;
+
         if (!request.urls.empty() && katrix::is_url(request.urls.front()))
           outbound.urls = FetchFiles(request.urls, katrix::get_media_dir());
+
         klog().d("Sending request {} to Katrix", outbound.id);
+
         m_worker.send(BotRequestToIPC(Platform::instagram, outbound));
         m_last_req = outbound;
         m_posts[request.id] = false;


### PR DESCRIPTION
- Reading config properly
- not enforcing flood protection for `instagram:query` requests