### PR TITLE
Worker Cleanup

### DIFF
--- a/src/bot/broker/broker.hpp
+++ b/src/bot/broker/broker.hpp
@@ -84,8 +84,6 @@ namespace kbot
   Broker(ipc_fail_fn _cb)
   : m_on_ipc_fail(_cb)
   {
-    kiq::log::klogger::init("botbroker", "trace");
-
     const auto execpath = get_executable_cwd();
     const auto config   = INIReader{execpath + "/../config/config.ini"};
 


### PR DESCRIPTION
The socket workers need to clean themselves up when we do a stop. We aren't otherwise giving them an opportunity to exit the loop or join themselves